### PR TITLE
Fixed other mods' biomes trying to generate in the Erebus

### DIFF
--- a/src/main/java/erebus/world/WorldChunkManagerErebus.java
+++ b/src/main/java/erebus/world/WorldChunkManagerErebus.java
@@ -34,8 +34,7 @@ public class WorldChunkManagerErebus extends WorldChunkManager
 	{
 		biomesToSpawnIn = new ArrayList(allowedBiomes);
 		biomeCache = new BiomeCache(this);
-		GenLayer[] layers = GenLayerErebus.initializeAllBiomeGenerators(world.getSeed(), world.getWorldInfo().getTerrainType());
-		biomeGenLayer = getModdedBiomeGenerators(world.getWorldInfo().getTerrainType(), world.getSeed(), layers)[1];
+		biomeGenLayer = GenLayerErebus.initializeAllBiomeGenerators(world.getSeed(), world.getWorldInfo().getTerrainType())[1];
 	}
 
 	@Override


### PR DESCRIPTION
I've been receiving complaints that my mod conflicts with the Erebus, because my biomes are trying to generate in the Erebus, and can't be cast to BiomeBaseErebus.
I'd found this issue back in January and told Dylan about it, but he doesn't seem to have passed it on.
For whatever reason, you've got a line of code in there pulling in other mods' genlayers. If there's a purpose to it, I can't see it, so I removed the code.
