### PR TITLE
Tried to make oregen disableable and failed

### DIFF
--- a/src/main/java/erebus/core/handler/configs/ConfigHandler.java
+++ b/src/main/java/erebus/core/handler/configs/ConfigHandler.java
@@ -25,7 +25,7 @@ public class ConfigHandler {
 	public int erebusDimensionID;
 	public int portalCooldown;
 	public byte beetleLarvaEating = 0;
-	public boolean spawnPortalMobs, bombardierBlockDestroy, randomNames, playCustomSongs, lead, silver, copper, tin, aluminium, alternativePlanks, graveMarker, bioluminescence, glowshrooms, generateVents, allowRespawning, netherWidows;
+	public boolean spawnPortalMobs, bombardierBlockDestroy, randomNames, playCustomSongs, coal, iron, gold, lapis, emerald, diamond, diamond_encrusted, jade, petrified_wood, fossil, gneiss, lead, silver, copper, tin, aluminium, alternativePlanks, graveMarker, bioluminescence, glowshrooms, generateVents, allowRespawning, netherWidows;
 
 	public boolean disableThaumcraft = false, disableFMP = false;
 
@@ -70,6 +70,16 @@ public class ConfigHandler {
 		generateVents = config.get(Configuration.CATEGORY_GENERAL, "Generate natural swap vents", true).getBoolean(true);
 		netherWidows = config.get(Configuration.CATEGORY_GENERAL, "Spawn Black Widows in Nether", true).getBoolean(true);
 
+		coal = config.get("Ores", "Generate coal", true).getBoolean(true);
+		iron = config.get("Ores", "Generate iron", true).getBoolean(true);
+		lapis = config.get("Ores", "Generate lapis lazuli", true).getBoolean(true);
+		emerald = config.get("Ores", "Generate emerald", true).getBoolean(true);
+		diamond = config.get("Ores", "Generate diamond", true).getBoolean(true);
+//		diamond_encrusted = config.get("Ores", "Generate encrusted diamond(this option does nothing right now)", false).getBoolean(false);
+		jade = config.get("Ores", "Generate jade", true).getBoolean(true);
+		petrified_wood = config.get("Ores", "Generate petrified wood", true).getBoolean(true);
+		fossil = config.get("Ores", "Generate fossil", true).getBoolean(true);
+//		gneiss = config.get("Ores", "Generate gneiss(this option does nothing right now)", false).getBoolean(false);
 		lead = config.get("Ores", "Generate lead", false).getBoolean(false);
 		silver = config.get("Ores", "Generate silver", false).getBoolean(false);
 		copper = config.get("Ores", "Generate copper", false).getBoolean(false);

--- a/src/main/java/erebus/world/biomes/decorators/data/OreSettings.java
+++ b/src/main/java/erebus/world/biomes/decorators/data/OreSettings.java
@@ -146,34 +146,34 @@ public final class OreSettings {
 
 			switch (this) {
 				case COAL:
-					settings.setIterations(extraOres ? 6 : 8).setOreAmount(9, 12);
+					settings.setChance(ConfigHandler.INSTANCE.coal ? 1F : 0F).setIterations(extraOres ? 6 : 8).setOreAmount(9, 12);
 					break;
 				case IRON:
-					settings.setIterations(extraOres ? 7 : 9, extraOres ? 8 : 10).setOreAmount(6, 10);
+					settings.setChance(ConfigHandler.INSTANCE.iron ? 1F : 0F).setIterations(extraOres ? 7 : 9, extraOres ? 8 : 10).setOreAmount(6, 10);
 					break;
 				case GOLD:
-					settings.setIterations(extraOres ? 4 : 5).setOreAmount(6);
+					settings.setChance(ConfigHandler.INSTANCE.gold ? 1F : 0F).setIterations(extraOres ? 4 : 5).setOreAmount(6);
 					break;
 				case LAPIS:
-					settings.setIterations(3).setOreAmount(5).setCheckArea(2);
+					settings.setChance(ConfigHandler.INSTANCE.lapis ? 1F : 0F).setIterations(3).setOreAmount(5).setCheckArea(2);
 					break;
 				case EMERALD:
-					settings.setChance(0.33F).setIterations(0, 2).setOreAmount(3).setCheckArea(1);
+					settings.setChance(ConfigHandler.INSTANCE.emerald ? 0.33F : 0F).setIterations(0, 2).setOreAmount(3).setCheckArea(1);
 					break;
 				case DIAMOND:
-					settings.setChance(0.66F).setIterations(2, 4).setOreAmount(1).setCheckArea(1);
+					settings.setChance(ConfigHandler.INSTANCE.diamond ? 0.66F : 0F).setIterations(2, 4).setOreAmount(1).setCheckArea(1);
 					break;
 				case DIAMOND_ENCRUSTED:
-					settings.setChance(0F);
+					settings.setChance(ConfigHandler.INSTANCE.diamond_encrusted ? 0F : 0F);
 					break;
 				case JADE:
-					settings.setChance(0.5F).setIterations(1, 4).setOreAmount(4).setCheckArea(2);
+					settings.setChance(ConfigHandler.INSTANCE.jade ? 0.5F : 0F).setIterations(1, 4).setOreAmount(4).setCheckArea(2);
 					break;
 				case PETRIFIED_WOOD:
-					settings.setIterations(extraOres ? 1 : 2, extraOres ? 3 : 4).setOreAmount(7, 9).setCheckArea(2);
+					settings.setChance(ConfigHandler.INSTANCE.petrified_wood ? 1F : 0F).setIterations(extraOres ? 1 : 2, extraOres ? 3 : 4).setOreAmount(7, 9).setCheckArea(2);
 					break;
 				case FOSSIL:
-					settings.setChance(0.25F).setIterations(1, 2).setOreAmount(8, 11).setY(36, 112);
+					settings.setChance(ConfigHandler.INSTANCE.fossil ? 0.25F : 0F).setIterations(1, 2).setOreAmount(8, 11).setY(36, 112);
 					break;
 				case ALUMINIUM:
 					settings.setChance(ConfigHandler.INSTANCE.aluminium ? 1F : 0F).setIterations(2, 3).setOreAmount(3, 4).setCheckArea(2);


### PR DESCRIPTION
I tried to make it possible to disable the generation of vanilla erebus ores because I needed that for my modpack. However I have failed since the ores still generate (I was not able to confirm this for lapis and diamond).
