### PR TITLE
Update Mappings (A must)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ minecraft {
     // stable_#            stables are built at the discretion of the MCP team.
     // Use non-default mappings at your own risk. they may not allways work.
     // simply re-run your setup task after changing the mappings to update your workspace.
-    mappings = "snapshot_20171003"
+    mappings = "stable_39"
     // makeObfSourceJar = false // an Srg named sources jar is made by default. uncomment this to disable.
 }
 


### PR DESCRIPTION
The mappings that were used were about 14 **Months** old.
- 20171003 - 03/10/2017 (DD/MM/YYYY)
- stable_39 is the now "standartized" version to be used in 1.12.2